### PR TITLE
Fix missing blogUri in menu

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -15,6 +15,7 @@ module.exports = {
         dynamicComments: 1,
         gaTrackingId: 0,
         wpPages: 1,
+        menuName: 'PRIMARY',
         wordPressUrl: 'https://data.staticfuse.com',
         blogURI: '/blog'
       },

--- a/gatsby-theme-publisher/src/components/Menu.js
+++ b/gatsby-theme-publisher/src/components/Menu.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Link, StaticQuery, graphql } from 'gatsby'
-import { createLocalLink } from '../utils'
+import { CreateLocalLink } from '../utils'
 import useSiteMetadata from '../hooks/use-site-metadata'
 import usePublisherMenu from '../hooks/use-publisher-menu'
 import { IconButton, Box } from '@chakra-ui/core'
@@ -68,7 +68,7 @@ const Menu = ({ location }) => {
     return false
   }
 
-  const renderLink = (menuItem, wordPressUrl) =>
+  const renderLink = (menuItem) =>
     menuItem.connectedObject &&
     menuItem.connectedObject.__typename === 'WPGraphQL_MenuItem' &&
     menuItem.url !== '/' ? (
@@ -84,13 +84,13 @@ const Menu = ({ location }) => {
           {menuItem.label}
         </Box>
       </Box>
-    ) : createLocalLink(menuItem.url, wordPressUrl) ? (
+    ) : CreateLocalLink(menuItem) ? (
       <Link
         style={{
           textDecoration: 'none',
           display: 'block',
         }}
-        to={createLocalLink(menuItem.url, wordPressUrl)}
+        to={CreateLocalLink(menuItem)}
       >
         <Box as="span" color="navLink" py={[2, 2, '0']} display="block">
           {menuItem.label}
@@ -100,7 +100,7 @@ const Menu = ({ location }) => {
       menuItem.label
     )
 
-  const renderSubMenu = (items, wordPressUrl) => (
+  const renderSubMenu = (items) => (
     <>
       <IconButton
         aria-label="open sub menu"
@@ -152,7 +152,7 @@ const Menu = ({ location }) => {
         opacity={subMenuOpen ? '1' : '0'}
       >
         {items.map(subItem => {
-          return renderMenuItem(subItem, wordPressUrl, false)
+          return renderMenuItem(subItem, false)
         })}
       </Box>
     </>
@@ -180,7 +180,7 @@ const Menu = ({ location }) => {
     }
   }
 
-  const renderMenuItem = (menuItem, wordPressUrl, border = false) => {
+  const renderMenuItem = (menuItem, border = false) => {
     return (
       <Box
         as="li"
@@ -215,9 +215,9 @@ const Menu = ({ location }) => {
         onMouseEnter={() => handleMouseEnter(menuItem)}
         onMouseLeave={() => handleMouseLeave(menuItem)}
       >
-        {renderLink(menuItem, wordPressUrl)}
+        {renderLink(menuItem)}
         {menuItem.childItems && menuItem.childItems.nodes.length
-          ? renderSubMenu(menuItem.childItems.nodes, wordPressUrl)
+          ? renderSubMenu(menuItem.childItems.nodes)
           : null}
       </Box>
     )

--- a/gatsby-theme-publisher/src/utils/index.js
+++ b/gatsby-theme-publisher/src/utils/index.js
@@ -5,7 +5,7 @@ import useSiteMetadata from '../hooks/use-site-metadata';
  *
  * @param {object} menuItem a single menu item
  */
-export const CreateLocalLink = ( menuItem ) => {
+export const CreateLocalLink = (menuItem) => {
   const { blogURI, wordPressUrl } = useSiteMetadata();
   const {url, connectedObject } = menuItem;
 

--- a/gatsby-theme-publisher/src/utils/index.js
+++ b/gatsby-theme-publisher/src/utils/index.js
@@ -1,9 +1,28 @@
-export const createLocalLink = ( url, wordPressUrl ) => {
+import useSiteMetadata from '../hooks/use-site-metadata';
+
+/**
+ * Parses a menu item object and returns Gatsby-fied URI.
+ *
+ * @param {object} menuItem a single menu item
+ */
+export const CreateLocalLink = ( menuItem ) => {
+  const { blogURI, wordPressUrl } = useSiteMetadata();
+  const {url, connectedObject } = menuItem;
 
   if (`#` === url) {
     return null
   }
-  let newUrl = url.replace(wordPressUrl, ``)
+  /**
+   * Alway want to pull of our API URL.
+   */
+  let newUri = url.replace(wordPressUrl, '');
 
-  return newUrl
+  /**
+   * If it's a blog link, respect the users blogURI setting.
+   */
+  if (connectedObject && connectedObject.__typename === 'WPGraphQL_Post') {
+    newUri = blogURI + newUri;
+  }
+
+  return newUri;
 }


### PR DESCRIPTION
This closes [this issue](https://github.com/staticfuse/gatsby-theme-publisher/issues/27)

Also cleans up the function a bit and the menu file. No need to pass around `wordPressUrl` now that I'm pulling in the site settings [here].(https://github.com/staticfuse/gatsby-theme-publisher/compare/patch-create-local-link?expand=1#diff-79bcc20a1159e88713267833e5122637R9)

Capitalized the function otherwise react will complain about using a hook in a non functional component. 

@scottopolis 

